### PR TITLE
Prevent Deprecated functionality exception

### DIFF
--- a/Observer/SaveGaUserId.php
+++ b/Observer/SaveGaUserId.php
@@ -81,7 +81,7 @@ class SaveGaUserId implements ObserverInterface
      */
     protected function getUserIdFromCookie()
     {
-        $gaCookie = explode('.', $this->cookieManager->getCookie('_ga'));
+        $gaCookie = explode('.', $this->cookieManager->getCookie('_ga') ?? '');
 
         if (empty($gaCookie) || count($gaCookie) < 4) {
             return null;


### PR DESCRIPTION
In PHP 8 calling explode with "null" as argument will throw a Deprecated functionality exception