### PR TITLE
Add support for GA4

### DIFF
--- a/Model/UAClient.php
+++ b/Model/UAClient.php
@@ -1,0 +1,177 @@
+<?php
+namespace Elgentos\ServerSideAnalytics\Model;
+
+use TheIconic\Tracking\GoogleAnalytics\Analytics;
+
+class UAClient {
+
+    const GOOGLE_ANALYTICS_SERVERSIDE_ENABLED        = 'google/serverside_analytics/enabled';
+    const GOOGLE_ANALYTICS_SERVERSIDE_UA             = 'google/serverside_analytics/ua';
+    const GOOGLE_ANALYTICS_SERVERSIDE_DEBUG_MODE     = 'google/serverside_analytics/debug_mode';
+    const GOOGLE_ANALYTICS_SERVERSIDE_ENABLE_LOGGING = 'google/serverside_analytics/enable_logging';
+
+
+    /* Analytics object which holds transaction data */
+    protected $analytics;
+
+    /* Google Analytics Measurement Protocol API version */
+    protected $version = '1';
+
+    /* Count how many products are added to the Analytics object */
+    protected $productCounter = 0;
+    /**
+     * @var \Magento\Framework\App\State
+     */
+    private $state;
+    /**
+     * @var \Magento\Framework\App\Config\ScopeConfigInterface
+     */
+    private $scopeConfig;
+    /**
+     * @var \Psr\Log\LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * Elgentos_ServerSideAnalytics_Model_GAClient constructor.
+     * @param \Magento\Framework\App\State $state
+     * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
+     */
+    public function __construct(\Magento\Framework\App\State $state,
+                                \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
+                                \Psr\Log\LoggerInterface $logger
+    )
+    {
+        $this->state = $state;
+        $this->scopeConfig = $scopeConfig;
+
+        /** @var Analytics analytics */
+        $this->analytics = new Analytics(true);
+
+        if ($this->scopeConfig->isSetFlag(self::GOOGLE_ANALYTICS_SERVERSIDE_DEBUG_MODE)) {
+            // $this->analytics = new Analytics(true, true); // for dev/staging envs where dev mode is off but we don't want to send events
+            $this->analytics->setDebug(true);
+        }
+        $this->logger = $logger;
+    }
+
+    /**
+     * @param \Magento\Framework\DataObject $data
+     * @throws \Exception
+     */
+    public function setTrackingData(\Magento\Framework\DataObject $data)
+    {
+        if (!$data->getTrackingId()) {
+            throw new \Exception('No tracking ID set for GA client.');
+        }
+
+        if (!$data->getClientId() && !$data->getUserId()) {
+            throw new \Exception('No client ID or user ID is set for GA client; at least one is necessary.');
+        }
+
+        $this->analytics->setProtocolVersion($this->version)
+            ->setTrackingId($data->getTrackingId()) // 'UA-26293624-12'
+            ->setIpOverride($data->getIpOverride()); // '123'
+
+        if ($data->getClientId()) {
+            $this->analytics->setClientId($data->getClientId()); // '2133506694.1448249699'
+        }
+
+        if ($data->getUserId()) {
+            $this->analytics->setUserId($data->getUserId());
+        }
+
+        if ($data->getUserAgentOverride()) {
+            $this->analytics->setUserAgentOverride($data->getUserAgentOverride());
+        }
+
+        if ($data->getDocumentPath()) {
+            $this->analytics->setDocumentPath($data->getDocumentPath());
+        }
+    }
+
+    /**
+     * @param $data
+     */
+    public function setTransactionData($data)
+    {
+        $this->analytics
+            ->setTransactionId($data->getTransactionId())
+            ->setRevenue($data->getRevenue())
+            ->setTax($data->getTax())
+            ->setShipping($data->getShipping());
+
+        if ($data->getAffiliation()) {
+            $this->analytics->setAffiliation($data->getAffiliation());
+        }
+
+        if ($data->getCouponCode()) {
+            $this->analytics->setCouponCode($data->getCouponCode());
+        }
+    }
+
+    /**
+     * @param $products
+     */
+    public function addProducts($products)
+    {
+        foreach ($products as $product) {
+            $this->addProduct($product);
+        }
+    }
+
+    /**
+     * @param $data
+     */
+    public function addProduct($data)
+    {
+        $this->productCounter++;
+        $this->analytics->addProduct($data->getData());
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function firePurchaseEvent()
+    {
+        if (!$this->analytics->getTransactionId()) {
+            throw new \Exception(__('No tracking ID set for transaction'));
+        }
+
+        if (!$this->analytics->getClientId() && !$this->analytics->getUserId()) {
+            throw new \Exception(__('No client ID or user ID set for transaction %s', $this->analytics->getTransactionId()));
+        }
+
+        if (!$this->analytics->getTrackingId()) {
+            throw new \Exception(__('No tracking ID set for transaction %s', $this->analytics->getTransactionId()));
+        }
+
+        if (!$this->productCounter) {
+            throw new \Exception(__('No products have been added to transaction %s', $this->analytics->getTransactionId()));
+        }
+
+        $this->analytics->setProductActionToPurchase();
+
+        $response = $this->analytics->setEventCategory('Checkout')
+            ->setEventAction('Purchase')
+            ->sendEvent();
+
+        // @codingStandardsIgnoreStart
+        if ($this->scopeConfig->isSetFlag(self::GOOGLE_ANALYTICS_SERVERSIDE_DEBUG_MODE)) {
+            $this->logger->info('elgentos_serversideanalytics_debug_response: ', array($response->getDebugResponse()));
+        }
+        if ($this->scopeConfig->isSetFlag(self::GOOGLE_ANALYTICS_SERVERSIDE_ENABLE_LOGGING)) {
+            $this->logger->info('elgentos_serversideanalytics_requests: ', array($response->getRequestUrl()));
+        }
+        // @codingStandardsIgnoreEnd
+    }
+
+    /**
+     * @return string
+     */
+    public function getVersion(): string
+    {
+        return $this->version;
+    }
+
+}

--- a/Observer/SaveGaUserId.php
+++ b/Observer/SaveGaUserId.php
@@ -2,29 +2,47 @@
 
 namespace Elgentos\ServerSideAnalytics\Observer;
 
-use Elgentos\ServerSideAnalytics\Model\GAClient;
+use Psr\Log\LoggerInterface;
 use Magento\Framework\Event\Observer;
-use Magento\Framework\Event\ObserverInterface;
 use Magento\Store\Model\ScopeInterface;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Quote\Api\CartRepositoryInterface;
+use Elgentos\ServerSideAnalytics\Model\GAClient;
+use Elgentos\ServerSideAnalytics\Model\UAClient;
+use Magento\Framework\Stdlib\CookieManagerInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 
 class SaveGaUserId implements ObserverInterface
 {
     /**
-     * @var \Magento\Framework\App\Config\ScopeConfigInterface
+     * @var ScopeConfigInterface
      */
     private $scopeConfig;
+
     /**
-     * @var \Psr\Log\LoggerInterface
+     * @var LoggerInterface
      */
     private $logger;
+
     /**
-     * @var \Magento\Framework\Stdlib\CookieManagerInterface
+     * @var CookieManagerInterface
      */
     private $cookieManager;
+
     /**
      * @var GAClient
      */
     private $gaclient;
+
+    /**
+     * @var UAClient
+     */
+    private $uaclient;
+
+    /**
+     * @var CartRepositoryInterface
+     */
+    protected $quoteRepository;
 
     /**
      * SaveGaUserId constructor.
@@ -32,44 +50,57 @@ class SaveGaUserId implements ObserverInterface
      * @param \Psr\Log\LoggerInterface $logger
      * @param \Magento\Framework\Stdlib\CookieManagerInterface $cookieManager
      * @param GAClient $gaclient
+     * @param UAClient $uaclient
+     * @param CartRepositoryInterface $quoteRepository
      */
-    public function __construct(\Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
-                                \Psr\Log\LoggerInterface $logger,
-                                \Magento\Framework\Stdlib\CookieManagerInterface $cookieManager,
-                                GAClient $gaclient)
-    {
+    public function __construct(
+        ScopeConfigInterface $scopeConfig,
+        LoggerInterface $logger,
+        CookieManagerInterface $cookieManager,
+        GAClient $gaclient,
+        UAClient $uaclient,
+        CartRepositoryInterface $quoteRepository
+    ) {
         $this->scopeConfig = $scopeConfig;
         $this->logger = $logger;
         $this->cookieManager = $cookieManager;
         $this->gaclient = $gaclient;
+        $this->uaclient = $uaclient;
+        $this->quoteRepository = $quoteRepository;
     }
 
     /**
      * When Order object is saved add the GA User Id if available in the cookies.
      *
-     * @param \Magento\Framework\Event\Observer $observer
+     * @param Observer $observer
      */
 
     public function execute(Observer $observer)
     {
-        if (!$this->scopeConfig->getValue(GAClient::GOOGLE_ANALYTICS_SERVERSIDE_ENABLED, ScopeInterface::SCOPE_STORE)) {
+        if (
+            !$this->scopeConfig->getValue(GAClient::GOOGLE_ANALYTICS_SERVERSIDE_ENABLED, ScopeInterface::SCOPE_STORE) &&
+            !$this->scopeConfig->getValue(UAClient::GOOGLE_ANALYTICS_SERVERSIDE_ENABLED, ScopeInterface::SCOPE_STORE)
+        ) {
             return;
         }
 
-        if (!$this->scopeConfig->getValue(GAClient::GOOGLE_ANALYTICS_SERVERSIDE_UA, ScopeInterface::SCOPE_STORE)) {
-            $this->logger->info('No Google Analytics account number has been found in the ServerSideAnalytics configuration.');
+        if (
+            !$this->scopeConfig->getValue(GAClient::GOOGLE_ANALYTICS_SERVERSIDE_API_SECRET, ScopeInterface::SCOPE_STORE) &&
+            !$this->scopeConfig->getValue(UAClient::GOOGLE_ANALYTICS_SERVERSIDE_UA, ScopeInterface::SCOPE_STORE)
+        ) {
+            $this->logger->info('No Google Analytics secret or UA has been found in the ServerSideAnalytics configuration.');
             return;
         }
 
-        $gaUserId = $this->getUserIdFromCookie();
+        $order = $observer->getEvent()->getOrder();
+        $quote = $this->quoteRepository->get($order->getQuoteId());
+        $gaUserId = $quote->getData('ga_user_id') ?: $this->getUserIdFromCookie();
         if ($gaUserId === null) {
             $gaCookieUserId = random_int(1E8, 1E9);
             $gaCookieTimestamp = time();
             $gaUserId = implode('.', [$gaCookieUserId, $gaCookieTimestamp]);
             $this->logger->info('Google Analytics cookie not found, generated temporary value: ' . $gaUserId);
         }
-
-        $order = $observer->getEvent()->getOrder();
 
         $order->setData('ga_user_id', $gaUserId);
     }
@@ -98,7 +129,10 @@ class SaveGaUserId implements ObserverInterface
             return null;
         }
 
-        if ($gaCookieVersion != 'GA' . $this->gaclient->getVersion()) {
+        if (
+            $gaCookieVersion != 'GA' . $this->gaclient->getVersion() &&
+            $gaCookieVersion != 'UA' . $this->uaclient->getVersion()
+        ) {
             $this->logger->info('Google Analytics cookie version differs from Measurement Protocol API version; please upgrade.');
             return null;
         }

--- a/Observer/SendPurchaseEvent.php
+++ b/Observer/SendPurchaseEvent.php
@@ -4,8 +4,8 @@ namespace Elgentos\ServerSideAnalytics\Observer;
 
 use Magento\Framework\DataObject;
 use Magento\Framework\Event\Observer;
-use Magento\Framework\Event\ObserverInterface;
 use Magento\Store\Model\ScopeInterface;
+use Magento\Framework\Event\ObserverInterface;
 use Elgentos\ServerSideAnalytics\Model\GAClient;
 use Elgentos\ServerSideAnalytics\Model\UAClient;
 
@@ -28,6 +28,10 @@ class SendPurchaseEvent implements ObserverInterface
      */
     private $gaclient;
     /**
+     * @var \Elgentos\ServerSideAnalytics\Model\UAClient
+     */
+    private $uaclient;
+    /**
      * @var \Magento\Framework\Event\ManagerInterface
      */
     private $event;
@@ -37,12 +41,14 @@ class SendPurchaseEvent implements ObserverInterface
         \Magento\Store\Model\App\Emulation $emulation,
         \Psr\Log\LoggerInterface $logger,
         \Elgentos\ServerSideAnalytics\Model\GAClient $gaclient,
+        \Elgentos\ServerSideAnalytics\Model\UAClient $uaclient,
         \Magento\Framework\Event\ManagerInterface $event
     ) {
         $this->scopeConfig = $scopeConfig;
         $this->emulation = $emulation;
         $this->logger = $logger;
         $this->gaclient = $gaclient;
+        $this->uaclient = $uaclient;
         $this->event = $event;
     }
 
@@ -75,6 +81,7 @@ class SendPurchaseEvent implements ObserverInterface
         }
 
         $products = [];
+
         /** @var \Magento\Sales\Model\Order\Invoice\Item $item */
         foreach ($invoice->getAllItems() as $item) {
             if (!$item->isDeleted() && !$item->getOrderItem()->getParentItemId()) {
@@ -200,8 +207,7 @@ class SendPurchaseEvent implements ObserverInterface
     private function getPaidShippingCosts(\Magento\Sales\Model\Order\Invoice $invoice)
     {
         return $this->scopeConfig->getValue('tax/display/type') == \Magento\Tax\Model\Config::DISPLAY_TYPE_EXCLUDING_TAX
-            ? $invoice->getShippingAmount()
-            : $invoice->getShippingInclTax();
+            ? $invoice->getBaseShippingAmount()
+            : $invoice->getBaseShippingInclTax();
     }
-
 }

--- a/Observer/SendPurchaseEvent.php
+++ b/Observer/SendPurchaseEvent.php
@@ -2,11 +2,12 @@
 
 namespace Elgentos\ServerSideAnalytics\Observer;
 
-use Elgentos\ServerSideAnalytics\Model\GAClient;
 use Magento\Framework\DataObject;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Store\Model\ScopeInterface;
+use Elgentos\ServerSideAnalytics\Model\GAClient;
+use Elgentos\ServerSideAnalytics\Model\UAClient;
 
 class SendPurchaseEvent implements ObserverInterface
 {
@@ -14,6 +15,10 @@ class SendPurchaseEvent implements ObserverInterface
      * @var \Magento\Framework\App\Config\ScopeConfigInterface
      */
     private $scopeConfig;
+    /**
+     * @var \Magento\Store\Model\App\Emulation
+     */
+    private $emulation;
     /**
      * @var \Psr\Log\LoggerInterface
      */
@@ -29,11 +34,13 @@ class SendPurchaseEvent implements ObserverInterface
 
     public function __construct(
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
+        \Magento\Store\Model\App\Emulation $emulation,
         \Psr\Log\LoggerInterface $logger,
         \Elgentos\ServerSideAnalytics\Model\GAClient $gaclient,
         \Magento\Framework\Event\ManagerInterface $event
     ) {
         $this->scopeConfig = $scopeConfig;
+        $this->emulation = $emulation;
         $this->logger = $logger;
         $this->gaclient = $gaclient;
         $this->event = $event;
@@ -44,30 +51,28 @@ class SendPurchaseEvent implements ObserverInterface
      */
     public function execute(Observer $observer)
     {
-        if (!$this->scopeConfig->getValue(GAClient::GOOGLE_ANALYTICS_SERVERSIDE_ENABLED, ScopeInterface::SCOPE_STORE)) {
-            return;
-        }
-        $ua = $this->scopeConfig->getValue(GAClient::GOOGLE_ANALYTICS_SERVERSIDE_UA, ScopeInterface::SCOPE_STORE);
-        if (!$ua) {
-            $this->logger->info('No Google Analytics account number has been found in the ServerSideAnalytics configuration.');
-            return;
-        }
-
-
         /** @var \Magento\Sales\Model\Order\Payment $payment */
         $payment = $observer->getPayment();
-        /** @var \Magento\Sales\Model\Order\Invoice $invoice */
-        $invoice = $observer->getInvoice();
         /** @var \Magento\Sales\Model\Order $order */
         $order = $payment->getOrder();
 
-        if (!$order->getData('ga_user_id')) {
+        $this->emulation->startEnvironmentEmulation($order->getStoreId(), 'adminhtml');
+
+        if (
+            !$this->scopeConfig->getValue(GAClient::GOOGLE_ANALYTICS_SERVERSIDE_ENABLED, ScopeInterface::SCOPE_STORE) &&
+            !$this->scopeConfig->getValue(UAClient::GOOGLE_ANALYTICS_SERVERSIDE_ENABLED, ScopeInterface::SCOPE_STORE)
+        ) {
+            $this->emulation->stopEnvironmentEmulation();
             return;
         }
 
-        $uas = explode(',', $ua);
-        $uas = array_filter($uas);
-        $uas = array_map('trim', $uas);
+        /** @var \Magento\Sales\Model\Order\Invoice $invoice */
+        $invoice = $observer->getInvoice();
+
+        if (!$order->getData('ga_user_id')) {
+            $this->emulation->stopEnvironmentEmulation();
+            return;
+        }
 
         $products = [];
         /** @var \Magento\Sales\Model\Order\Invoice\Item $item */
@@ -80,8 +85,10 @@ class SendPurchaseEvent implements ObserverInterface
                     'quantity' => $item->getOrderItem()->getQtyOrdered(),
                     'position' => $item->getId()
                 ]);
+
                 $this->event->dispatch('elgentos_serversideanalytics_product_item_transport_object',
                     ['product' => $product, 'item' => $item]);
+
                 $products[] = $product;
             }
         }
@@ -92,29 +99,27 @@ class SendPurchaseEvent implements ObserverInterface
             'document_path' => '/checkout/onepage/success/'
         ]);
 
-        try {
-            /** @var \Elgentos\ServerSideAnalytics\Model\GAClient $client */
-            $client = $this->gaclient;
+        $transactionDataObject = $this->getTransactionDataObject($order, $invoice);
 
-            $client->setTransactionData($this->getTransactionDataObject($order, $invoice));
-
-            $client->addProducts($products);
-        } catch (\Exception $e) {
-            $this->logger->info($e);
-            return;
+        if ($this->scopeConfig->getValue(GAClient::GOOGLE_ANALYTICS_SERVERSIDE_ENABLED, ScopeInterface::SCOPE_STORE))
+        {
+            $this->sendPurchaseEvent($this->gaclient, $transactionDataObject, $products, $trackingDataObject);
         }
 
-        foreach ($uas as $ua) {
-            try {
+        if ($this->scopeConfig->getValue(UAClient::GOOGLE_ANALYTICS_SERVERSIDE_ENABLED, ScopeInterface::SCOPE_STORE))
+        {
+            $ua = $this->scopeConfig->getValue(UAClient::GOOGLE_ANALYTICS_SERVERSIDE_UA, ScopeInterface::SCOPE_STORE);
+            $uas = explode(',', $ua ?? '');
+            $uas = array_filter($uas);
+            $uas = array_map('trim', $uas);
+
+            foreach ($uas as $ua) {
                 $trackingDataObject->setData('tracking_id', $ua);
-                $client->setTrackingData($trackingDataObject);
-                $this->event->dispatch('elgentos_serversideanalytics_tracking_data_transport_object',
-                    ['tracking_data_object' => $trackingDataObject]);
-                $client->firePurchaseEvent();
-            } catch (\Exception $e) {
-                $this->logger->info($e);
+                $this->sendPurchaseEvent($this->uaclient, $transactionDataObject, $products, $trackingDataObject);
             }
         }
+        
+        $this->emulation->stopEnvironmentEmulation();
     }
 
     /**
@@ -129,8 +134,9 @@ class SendPurchaseEvent implements ObserverInterface
             [
                 'transaction_id' => $order->getIncrementId(),
                 'affiliation' => $order->getStoreName(),
+                'currency' => $invoice->getGlobalCurrencyCode(),
                 'revenue' => $invoice->getBaseGrandTotal(),
-                'tax' => $invoice->getTaxAmount(),
+                'tax' => $invoice->getBaseTaxAmount(),
                 'shipping' => ($this->getPaidShippingCosts($invoice) ?? 0),
                 'coupon_code' => $order->getCouponCode()
             ]
@@ -143,6 +149,36 @@ class SendPurchaseEvent implements ObserverInterface
     }
 
     /**
+     * @param $client
+     * @param DataObject $transactionDataObject
+     * @param array $products
+     * @param DataObject $trackingDataObject
+     */
+    public function sendPurchaseEvent($client, DataObject $transactionDataObject, array $products, DataObject $trackingDataObject)
+    {
+        try {
+            $client->setTransactionData($transactionDataObject);
+
+            $client->addProducts($products);
+        } catch (\Exception $e) {
+            $this->logger->info($e);
+            return;
+        }
+
+        try {
+            $client->setTrackingData($trackingDataObject);
+
+            $this->event->dispatch(
+                'elgentos_serversideanalytics_tracking_data_transport_object',
+                ['tracking_data_object' => $trackingDataObject]
+            );
+            $client->firePurchaseEvent();
+        } catch (\Exception $e) {
+            $this->logger->info($e);
+        }
+    }
+
+    /**
      * Get the actual price the customer also saw in it's cart.
      *
      * @param \Magento\Sales\Model\Order\Item $orderItem
@@ -152,8 +188,8 @@ class SendPurchaseEvent implements ObserverInterface
     private function getPaidProductPrice(\Magento\Sales\Model\Order\Item $orderItem)
     {
         return $this->scopeConfig->getValue('tax/display/type') == \Magento\Tax\Model\Config::DISPLAY_TYPE_EXCLUDING_TAX
-            ? $orderItem->getPrice()
-            : $orderItem->getPriceInclTax();
+            ? $orderItem->getBasePrice()
+            : $orderItem->getBasePriceInclTax();
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
   "description": "Elgentos_ServerSideAnalytics for magento 2",
   "require": {
     "php": ">=7.1.0",
-    "8ctopus/php-ga-measurement-protocol": "^2.0"
+    "br33f/php-ga4-mp": "^0.1.0",
+    "theiconic/php-ga-measurement-protocol": "^2.0"
   },
   "type": "magento2-module",
   "authors": [

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -5,13 +5,33 @@
             <group id="serverside_analytics" translate="label" type="text" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>ServerSide Google Analytics Options</label>
                 <field id="enabled" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
-                    <label>Enable</label>
+                    <label>Univeral Analytics Enable</label>
                     <comment><![CDATA[WARNING: even when you have this extension disabled, the regular frontend success event will be disabled. Completely remove this extension to re-enable the normal event on the success page.]]></comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+                <field id="ga_enabled" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Google Analytics 4 Enable</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
                 <field id="ua" translate="label" type="text" sortOrder="15" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Google Analytics UA tag</label>
                     <comment><![CDATA[For example, UA-12384573. Multiple container ID's can be used, separate by comma]]></comment>
+                    <depends>
+                        <field id="google/serverside_analytics/enabled">1</field>
+                    </depends>
+                </field>
+                <field id="api_secret" translate="label" type="text" sortOrder="15" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>API Secret</label>
+                    <depends>
+                        <field id="google/serverside_analytics/ga_enabled">1</field>
+                    </depends>
+                </field>
+                <field id="measurement_id" translate="label" type="text" sortOrder="15" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Google Analytics Measurement Id</label>
+                    <comment><![CDATA[For example, G-12384573]]></comment>
+                    <depends>
+                        <field id="google/serverside_analytics/ga_enabled">1</field>
+                    </depends>
                 </field>
                 <field id="debug_mode" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Enable Debug Mode</label>


### PR DESCRIPTION
This PR will add an option to either enable UA, enable GA4 or enable both at the same time (although they would use the same tracking id which seems to work from the testing i've done)
Config paths have been kept as is so it should not break existing installations (so long as no plugins have been made on the GAClient)

The old `Model/GAClient` had been renamed to `Model/UAClient` since this is the more appropriate name, other than that it shouldn't have changed.