### PR TITLE
Fixed issue with random_int

### DIFF
--- a/Observer/SaveGaUserId.php
+++ b/Observer/SaveGaUserId.php
@@ -96,7 +96,7 @@ class SaveGaUserId implements ObserverInterface
         $quote = $this->quoteRepository->get($order->getQuoteId());
         $gaUserId = $quote->getData('ga_user_id') ?: $this->getUserIdFromCookie();
         if ($gaUserId === null) {
-            $gaCookieUserId = random_int(1E8, 1E9);
+            $gaCookieUserId = random_int((int)1E8, (int)1E9);
             $gaCookieTimestamp = time();
             $gaUserId = implode('.', [$gaCookieUserId, $gaCookieTimestamp]);
             $this->logger->info('Google Analytics cookie not found, generated temporary value: ' . $gaUserId);


### PR DESCRIPTION
The method random_int expects int as parameters. 1E8 and 1E9 result in floats, so they have to be cast. Otherwise, the whole thing runs into a type error

<img width="1385" alt="CleanShot 2022-10-10 at 10 33 42@2x" src="https://user-images.githubusercontent.com/1841317/194826684-90ebca5d-2b15-44ac-baad-76aff365d50a.png">
