### PR TITLE
Fix GA1 cookie check

### DIFF
--- a/Observer/SaveGaUserId.php
+++ b/Observer/SaveGaUserId.php
@@ -130,7 +130,7 @@ class SaveGaUserId implements ObserverInterface
         }
 
         if (
-            $gaCookieVersion != 'GA' . $this->gaclient->getVersion() &&
+            $gaCookieVersion != 'GA1' &&
             $gaCookieVersion != 'UA' . $this->uaclient->getVersion()
         ) {
             $this->logger->info('Google Analytics cookie version differs from Measurement Protocol API version; please upgrade.');


### PR DESCRIPTION
The cookie is GA1, not GA4.
Fixes https://github.com/elgentos/magento2-serversideanalytics/issues/20

(UA can be removed anyways but okay).

Note: I'm deploying this to production now, so wil have to wait till tomorrow to see the results.