### PR TITLE
Update GAClient.php

### DIFF
--- a/Model/GAClient.php
+++ b/Model/GAClient.php
@@ -71,7 +71,8 @@ class GAClient {
             return $this->service;
         }
 
-        $this->service = new Service($this->getApiSecret(), $this->getMeasurementId());
+        $this->service = new Service($this->getApiSecret());
+        $this->service->setMeasurementId($this->getMeasurementId());
 
         return $this->service;
     }


### PR DESCRIPTION
Fixed bug in GaClient.php, with GA4 we cannot set the measurementId in the constructor