### PR TITLE
Use the order object that's already there instead of loading by ID

### DIFF
--- a/Observer/SendPurchaseEvent.php
+++ b/Observer/SendPurchaseEvent.php
@@ -59,8 +59,12 @@ class SendPurchaseEvent implements ObserverInterface
         $payment = $observer->getPayment();
 
         /** @var \Magento\Sales\Model\Order $order */
-        $order = $payment->getOrder();
-        $orderId = $order->getId();
+        $orderId = $payment->getOrder()->getId();
+
+        if (empty($orderId)) {
+            return;
+        }
+
         $orderStoreId = $payment->getOrder()->getStoreId();
 
         $this->emulation->startEnvironmentEmulation($orderStoreId, 'adminhtml');
@@ -75,6 +79,8 @@ class SendPurchaseEvent implements ObserverInterface
         /** @var \Magento\Sales\Model\Order\Invoice $invoice */
         $invoice = $observer->getInvoice();
 
+
+        $order = $this->orderRepository->get($orderId);
         $orderExtensionAttributes = $order->getExtensionAttributes();
 
         if (!$orderExtensionAttributes->getGaUserId()


### PR DESCRIPTION
This is a fix for 0 subtotal orders where the order does not yet have an ID when the invoice is made