### PR TITLE
Fallback to db if cookie id is null

### DIFF
--- a/Plugin/SaveGaUserDataToDb.php
+++ b/Plugin/SaveGaUserDataToDb.php
@@ -75,7 +75,7 @@ class SaveGaUserDataToDb
         }
 
         $gaUserId = ($this->getUserIdFromCookie() !== $elgentosSalesOrderData->getGaUserId()) ? ($this->getUserIdFromCookie() ?: $elgentosSalesOrderData->getGaUserId()) : $elgentosSalesOrderData->getGaUserId();
-        $gaSessionId = ($this->getSessionIdFromCookie() !== $elgentosSalesOrderData->getSessionId()) ? ($this->getSessionIdFromCookie() ?: $elgentosSalesOrderData->getSessionId()) : $elgentosSalesOrderData->getSessionId();
+        $gaSessionId = ($this->getSessionIdFromCookie() !== $elgentosSalesOrderData->getGaSessionId()) ? ($this->getSessionIdFromCookie() ?: $elgentosSalesOrderData->getGaSessionId()) : $elgentosSalesOrderData->getGaSessionId();
 
         if ($gaUserId === null) {
             $gaCookieUserId = random_int((int)1E8, (int)1E9);

--- a/Plugin/SaveGaUserDataToDb.php
+++ b/Plugin/SaveGaUserDataToDb.php
@@ -74,8 +74,8 @@ class SaveGaUserDataToDb
             return;
         }
 
-        $gaUserId = ($this->getUserIdFromCookie() !== $elgentosSalesOrderData->getGaUserId()) ? $this->getUserIdFromCookie() : $elgentosSalesOrderData->getGaUserId();
-        $gaSessionId = ($this->getSessionIdFromCookie() !== $elgentosSalesOrderData->getSessionId()) ? $this->getUserIdFromCookie() : $elgentosSalesOrderData->getGaUserId();
+        $gaUserId = ($this->getUserIdFromCookie() !== $elgentosSalesOrderData->getGaUserId()) ? ($this->getUserIdFromCookie() ?? $elgentosSalesOrderData->getGaUserId()) : $elgentosSalesOrderData->getGaUserId();
+        $gaSessionId = ($this->getSessionIdFromCookie() !== $elgentosSalesOrderData->getSessionId()) ? ($this->getSessionIdFromCookie() ?? $elgentosSalesOrderData->getSessionId()) : $elgentosSalesOrderData->getSessionId();
 
         if ($gaUserId === null) {
             $gaCookieUserId = random_int((int)1E8, (int)1E9);

--- a/Plugin/SaveGaUserDataToDb.php
+++ b/Plugin/SaveGaUserDataToDb.php
@@ -74,8 +74,8 @@ class SaveGaUserDataToDb
             return;
         }
 
-        $gaUserId = ($this->getUserIdFromCookie() !== $elgentosSalesOrderData->getGaUserId()) ? ($this->getUserIdFromCookie() ?? $elgentosSalesOrderData->getGaUserId()) : $elgentosSalesOrderData->getGaUserId();
-        $gaSessionId = ($this->getSessionIdFromCookie() !== $elgentosSalesOrderData->getSessionId()) ? ($this->getSessionIdFromCookie() ?? $elgentosSalesOrderData->getSessionId()) : $elgentosSalesOrderData->getSessionId();
+        $gaUserId = ($this->getUserIdFromCookie() !== $elgentosSalesOrderData->getGaUserId()) ? ($this->getUserIdFromCookie() ?: $elgentosSalesOrderData->getGaUserId()) : $elgentosSalesOrderData->getGaUserId();
+        $gaSessionId = ($this->getSessionIdFromCookie() !== $elgentosSalesOrderData->getSessionId()) ? ($this->getSessionIdFromCookie() ?: $elgentosSalesOrderData->getSessionId()) : $elgentosSalesOrderData->getSessionId();
 
         if ($gaUserId === null) {
             $gaCookieUserId = random_int((int)1E8, (int)1E9);


### PR DESCRIPTION
This fixes randomly generated user ids in case of headless instances. As the cookie will always be null.

Also sets the session id to the session id from cookie instead of the user id