### PR TITLE
Add an empty string as fallback to avoid errors

### DIFF
--- a/Model/Resolver/GAResolver.php
+++ b/Model/Resolver/GAResolver.php
@@ -52,11 +52,11 @@ class GAResolver implements ResolverInterface
 
         $elgentosSalesOrder->setQuoteId($cartId);
         if ($elgentosSalesOrder->getGaUserId() !== ($input['gaUserId'] ?? null)) {
-            $elgentosSalesOrder->setGaUserId($input['gaUserId']);
+            $elgentosSalesOrder->setGaUserId($input['gaUserId'] ?? '');
         }
 
         if ($elgentosSalesOrder->getGaSessionId() !== ($input['gaSessionId'] ?? null)) {
-            $elgentosSalesOrder->setGaSessionId($input['gaSessionId']);
+            $elgentosSalesOrder->setGaSessionId($input['gaSessionId'] ?? '');
         }
 
         $this->elgentosSalesOrderRepository->save($elgentosSalesOrder);


### PR DESCRIPTION
Add an empty string as fallback to avoid errors for when the gaUserId or gaSessionId is missing from the input array.

Occasionally, if no userId or sessionId is available, an exception is thrown:
```Warning: Undefined array key "gaSessionId"```


 This provides a fallback so that an exception is no longer thrown.