### PR TITLE
Prevent overriding real id in database with generated id

### DIFF
--- a/Plugin/SaveGaUserDataToDb.php
+++ b/Plugin/SaveGaUserDataToDb.php
@@ -67,6 +67,10 @@ class SaveGaUserDataToDb
             ->addFieldToFilter('quote_id', $quote->getId())
             ->getFirstItem();
 
+        if ($this->getUserIdFromCookie() === null && $elgentosSalesOrderData->getGaUserId() !== null) {
+            return;
+        }
+        
         if ($this->getGaUserId() === $elgentosSalesOrderData->getGaUserId()) {
             return;
         }


### PR DESCRIPTION
#50 introduced a bug for headless systems where real id's passed via Graphql are overridden by a generated id.
This is because the cookie will always be null, thus always generated and never matching the value in the database.

This change will skip generating and setting the user id only if the following conditions are true:
1. a ga user id is already set in the DB
2. no ga user id exists in the cookies