### PR TITLE
Fix getOrder being null for paypal express

### DIFF
--- a/Model/SendPurchaseEvent.php
+++ b/Model/SendPurchaseEvent.php
@@ -182,6 +182,7 @@ class SendPurchaseEvent
 
     /**
      * Get the actual price the customer also saw in it's cart.
+     * @phpstan-ignore-next-line
      */
     private function getPaidProductPrice(Item $orderItem): float|string
     {
@@ -219,6 +220,9 @@ class SendPurchaseEvent
         return $transactionDataObject;
     }
 
+    /**
+     * @phpstan-ignore-next-line
+     */
     private function getPaidShippingCosts(Order $order): null|float|string
     {
         return $this->moduleConfiguration->getTaxDisplayType($order->getStoreId()) == Config::DISPLAY_TYPE_EXCLUDING_TAX

--- a/Model/SendPurchaseEvent.php
+++ b/Model/SendPurchaseEvent.php
@@ -183,7 +183,7 @@ class SendPurchaseEvent
     /**
      * Get the actual price the customer also saw in it's cart.
      */
-    private function getPaidProductPrice(Item $orderItem): float
+    private function getPaidProductPrice(Item $orderItem): float|string
     {
         return $this->moduleConfiguration
             /** @phpstan-ignore-next-line */
@@ -219,7 +219,7 @@ class SendPurchaseEvent
         return $transactionDataObject;
     }
 
-    private function getPaidShippingCosts(Order $order): ?float
+    private function getPaidShippingCosts(Order $order): null|float|string
     {
         return $this->moduleConfiguration->getTaxDisplayType($order->getStoreId()) == Config::DISPLAY_TYPE_EXCLUDING_TAX
             ? $order->getBaseShippingAmount()

--- a/Model/SendPurchaseEvent.php
+++ b/Model/SendPurchaseEvent.php
@@ -186,7 +186,8 @@ class SendPurchaseEvent
     private function getPaidProductPrice(Item $orderItem): float
     {
         return $this->moduleConfiguration
-            ->getTaxDisplayType($orderItem->getOrder()->getStoreId()) === Config::DISPLAY_TYPE_EXCLUDING_TAX
+            /** @phpstan-ignore-next-line */
+            ->getTaxDisplayType($orderItem->getOrder()?->getStoreId()) === Config::DISPLAY_TYPE_EXCLUDING_TAX
             ? $orderItem->getBasePrice()
             : $orderItem->getBasePriceInclTax();
     }


### PR DESCRIPTION
Mistakes were made..
Although the getOrder function in an Order [Item->getOrder](https://github.com/magento/magento2/blob/6acfd6aa744c905f7694f2cddd5b0add5bf202b7/app/code/Magento/Sales/Model/Order/Item.php#L299) should always return a order, it doesn't with PaypalExpress.

And fix [#62](https://github.com/elgentos/magento2-serversideanalytics/issues/62)