### PR TITLE
Fix Argument #1 ($userId) must be of type ?string, int given

### DIFF
--- a/Model/GAClient.php
+++ b/Model/GAClient.php
@@ -50,7 +50,7 @@ class GAClient
         $this->getRequest()->setTimestampMicros($this->getMicroTime());
 
         if ($data->getUserId()) {
-            $this->getRequest()->setUserId($data->getUserId()); // magento customer_id
+            $this->getRequest()->setUserId((string) $data->getUserId()); // magento customer_id
         }
     }
 


### PR DESCRIPTION
Br33f GA4 requires setUserId to be a string, currently we're passing an int. Causing 
> Br33f\\Ga4\\MeasurementProtocol\\Dto\\Request\\BaseRequest::setUserId(): Argument #1 ($userId) must be of type ?string, int given, called in vendor/elgentos/serversideanalytics2/Model/GAClient.php on line 52