### PR TITLE
Move getting user id and session id to model, create GA Data if it was not set by cart

### DIFF
--- a/Model/SalesOrder.php
+++ b/Model/SalesOrder.php
@@ -9,12 +9,185 @@ declare(strict_types=1);
 
 namespace Elgentos\ServerSideAnalytics\Model;
 
+use Elgentos\ServerSideAnalytics\Config\ModuleConfiguration;
+use Elgentos\ServerSideAnalytics\Model\ResourceModel\SalesOrder\CollectionFactory;
+use Elgentos\ServerSideAnalytics\Model\Source\Fallback;
+use Magento\Framework\Data\Collection\AbstractDb;
 use Magento\Framework\Model\AbstractModel;
+use Magento\Framework\Model\Context;
+use Elgentos\ServerSideAnalytics\Model\ResourceModel\SalesOrder as SalesOrderResource;
+use Magento\Framework\Registry;
+use Magento\Framework\Stdlib\CookieManagerInterface;
 
 class SalesOrder extends AbstractModel
 {
+    public function __construct(
+        Context $context,
+        Registry $registry,
+        SalesOrderResource $resource = null,
+        AbstractDb $resourceCollection = null,
+        protected readonly ModuleConfiguration $moduleConfiguration,
+        protected readonly CollectionFactory $elgentosSalesOrderCollectionFactory,
+        protected readonly SalesOrderRepository $elgentosSalesOrderRepository,
+        protected readonly CookieManagerInterface $cookieManager,
+        protected readonly GAClient $gaclient,
+        array $data = []
+    ) {
+        parent::__construct($context, $registry, $resource, $resourceCollection, $data);
+    }
+
     protected function _construct(): void
     {
         $this->_init(ResourceModel\SalesOrder::class);
+    }
+
+    /**
+     * Set the ga_user_id and ga_session_id on the current sales order.
+     * Any missing data will be gathered from the cookies, or generated.
+     */
+    public function setGaData(int|null|string $storeId = null, null|string $gaUserId = null, int|null|string $gaSessionId = null): static
+    {
+        return $this->setData([
+            'ga_user_id' => $gaUserId ?? $this->getCurrentGaUserId(),
+            'ga_session_id' => $gaSessionId ?? $this->getCurrentGaSessionId($storeId),
+        ]);
+    }
+
+    /**
+     * Attemt to get the current GA User id from cookies, database or generating it.
+     */
+    public function getCurrentGaUserId(): string
+    {
+        $gaUserId = $this->getUserIdFromCookie($this->cookieManager->getCookie('_ga')) ?? $this->getGaUserId();
+
+        if (!$gaUserId) {
+            $gaUserId = $this->generateFallbackUserId();
+            $this->gaclient->createLog(
+                'Google Analytics cookie not found, generated temporary GA User Id: ' . $gaUserId
+            );
+        }
+
+        return (string) $gaUserId;
+    }
+
+    /**
+     * Attemt to get the current GA User id from cookies, database or generating it.
+     */
+    public function getCurrentGaSessionId(int|null|string $storeId = null): string
+    {
+        $measurementId = $this->moduleConfiguration->getMeasurementId($storeId);
+        $gaSessionId = $this->getSessionIdFromCookie(
+            $this->getSessionIdCookie($measurementId)
+        );
+
+        if ($gaSessionId) {
+            return $gaSessionId;
+        }
+
+        return (string) ($this->getGaSessionId() ?? $this->generateFallbackSessionId(
+            $this->moduleConfiguration->getFallbackGenerationMode($storeId),
+            $storeId
+        ));
+    }
+
+    /**
+     * Try to get the Google Analytics User ID from the cookie
+     */
+    public function getUserIdFromCookie($gaCookie = '' /** GA1.1.99999999.1732012836 */): ?string
+    {
+        $gaCookie = explode('.', $gaCookie ?? '');
+
+        if (count($gaCookie) < 4) {
+            return null;
+        }
+
+        [
+            $gaCookieVersion,
+            $gaCookieDomainComponents,
+            $gaCookieUserId,
+            $gaCookieTimestamp
+        ] = $gaCookie;
+
+        if (!$gaCookieUserId || !$gaCookieTimestamp) {
+            return null;
+        }
+
+        if (
+            $gaCookieVersion != 'GA' . $this->gaclient->getVersion()
+        ) {
+            $this->gaclient->createLog(
+                'Google Analytics cookie version differs from Measurement Protocol API version; please upgrade.'
+            );
+            return null;
+        }
+
+        return implode('.', [$gaCookieUserId, $gaCookieTimestamp]);
+    }
+
+    /**
+     * Generate a fallback analytics user id
+     */
+    public function generateFallbackUserId(): string
+    {
+        $gaCookieUserId = random_int((int)1E8, (int)1E9);
+        $gaCookieTimestamp = time();
+        $gaUserId = implode('.', [$gaCookieUserId, $gaCookieTimestamp]);
+
+        return $gaUserId;
+    }
+
+    public function getSessionIdCookie($gaMeasurementId = '' /** G-0XX00XXX */ ): string
+    {
+        $gaMeasurementId = str_replace('G-', '', $gaMeasurementId ?? '');
+
+        return $this->cookieManager->getCookie('_ga_' . $gaMeasurementId) ?? '';
+    }
+
+    public function getSessionIdFromCookie(?string $gaCookie = '' /** GS1.1.1732016998.2.1.1732018235.0.0.692404937 */): ?string
+    {
+        $gaCookie = explode(
+            '.',
+            $gaCookie ?? ''
+        );
+
+        if (count($gaCookie) < 9) {
+            return null;
+        }
+
+        [
+            $gaCookieVersion,
+            $gaCookieDomainComponents,
+            $gaCookieSessionStartTime,
+            $gaCookieSessionsCount,
+            $gaCookieEngagedSession,
+            $gaCookieLastEventTime,
+            $gaCookieCountdown,
+            $unknownZero1,
+            $unknownZero2,
+            $gaCookieEngagedTime,
+        ] = $gaCookie;
+
+        return (string) $gaCookieSessionStartTime;
+    }
+
+    /**
+     * Generate a fallback analytics session id
+     */
+    public function generateFallbackSessionId($fallbackGenerationMode = Fallback::DEFAULT, int|null|string $storeId = null): string
+    {
+        if ($fallbackGenerationMode === Fallback::DEFAULT) {
+            return (string) $this->moduleConfiguration->getFallbackSessionId() ?? '9999999999999';
+        }
+
+        if ($fallbackGenerationMode === Fallback::PREFIX) {
+            $prefix = $this->moduleConfiguration->getFallbackSessionIdPrefix($storeId);
+            if (!$prefix) {
+                $prefix = '9999';
+            }
+
+            return (string) $prefix . random_int((int)1E5, (int)1E6);
+        }
+
+        return (string) random_int((int)1E5, (int)1E9);
     }
 }

--- a/Model/SalesOrder.php
+++ b/Model/SalesOrder.php
@@ -71,7 +71,7 @@ class SalesOrder extends AbstractModel
     }
 
     /**
-     * Attemt to get the current GA User id from cookies, database or generating it.
+     * Attemt to get the current GA Session id from cookies, database or generating it.
      */
     public function getCurrentGaSessionId(int|null|string $storeId = null): string
     {

--- a/Model/SalesOrder.php
+++ b/Model/SalesOrder.php
@@ -47,10 +47,10 @@ class SalesOrder extends AbstractModel
      */
     public function setGaData(int|null|string $storeId = null, null|string $gaUserId = null, int|null|string $gaSessionId = null): static
     {
-        return $this->setData([
-            'ga_user_id' => $gaUserId ?? $this->getCurrentGaUserId(),
-            'ga_session_id' => $gaSessionId ?? $this->getCurrentGaSessionId($storeId),
-        ]);
+        $this->setData('ga_user_id', $gaUserId ?? $this->getCurrentGaUserId());
+        $this->setData('ga_session_id', $gaSessionId ?? $this->getCurrentGaSessionId($storeId));
+
+        return $this;
     }
 
     /**

--- a/Plugin/SaveGaUserDataToDb.php
+++ b/Plugin/SaveGaUserDataToDb.php
@@ -14,8 +14,6 @@ use Elgentos\ServerSideAnalytics\Model\GAClient;
 use Elgentos\ServerSideAnalytics\Model\ResourceModel\SalesOrder\Collection;
 use Elgentos\ServerSideAnalytics\Model\ResourceModel\SalesOrder\CollectionFactory;
 use Elgentos\ServerSideAnalytics\Model\SalesOrderRepository;
-use Elgentos\ServerSideAnalytics\Model\Source\Fallback;
-use Magento\Framework\Stdlib\CookieManagerInterface;
 use Magento\Quote\Api\CartRepositoryInterface;
 
 class SaveGaUserDataToDb
@@ -24,7 +22,6 @@ class SaveGaUserDataToDb
         protected readonly ModuleConfiguration $moduleConfiguration,
         protected readonly CollectionFactory $elgentosSalesOrderCollectionFactory,
         protected readonly SalesOrderRepository $elgentosSalesOrderRepository,
-        protected readonly CookieManagerInterface $cookieManager,
         protected readonly GAClient $gaclient
     ) {
     }
@@ -43,116 +40,22 @@ class SaveGaUserDataToDb
 
         /** @var Collection $elgentosSalesOrderCollection */
         $elgentosSalesOrderCollection = $this->elgentosSalesOrderCollectionFactory->create();
+        /** @var SalesOrder $elgentosSalesOrderData */
         $elgentosSalesOrderData = $elgentosSalesOrderCollection
             ->addFieldToFilter('quote_id', $quote->getId())
             ->getFirstItem();
 
-        if ($this->getGaUserId() === $elgentosSalesOrderData->getGaUserId()) {
+        if ($elgentosSalesOrderData->getCurrentGaUserId() === $elgentosSalesOrderData->getGaUserId()) {
             return;
         }
 
         $elgentosSalesOrderData->setData('quote_id', $quote->getId());
-        $elgentosSalesOrderData->setData('ga_user_id', $this->getGaUserId());
-        $elgentosSalesOrderData->setData('ga_session_id', $this->getGaSessionId($quote->getStoreId()));
+        $elgentosSalesOrderData->setGaData(storeId: $quote->getStoreId());
 
         try {
             $this->elgentosSalesOrderRepository->save($elgentosSalesOrderData);
         } catch (\Exception $exception) {
             $this->gaclient->createLog($exception->getMessage());
         }
-    }
-
-    protected function getGaUserId()
-    {
-        $gaUserId = $this->getUserIdFromCookie();
-
-        if ($gaUserId === null) {
-            $gaCookieUserId = random_int((int)1E8, (int)1E9);
-            $gaCookieTimestamp = time();
-            $gaUserId = implode('.', [$gaCookieUserId, $gaCookieTimestamp]);
-            $this->gaclient->createLog(
-                'Google Analytics cookie not found, generated temporary GA User Id: ' . $gaUserId
-            );
-        }
-
-        return $gaUserId;
-    }
-
-    protected function getGaSessionId(int|null|string $storeId = null)
-    {
-
-        $gaSessionId = $this->getSessionIdFromCookie($storeId);
-
-        if ($gaSessionId) {
-            return $gaSessionId;
-        }
-
-        if ($this->moduleConfiguration->getFallbackGenerationMode($storeId) === Fallback::DEFAULT) {
-            return $this->moduleConfiguration->getFallbackSessionId() ?? '9999999999999';
-        }
-
-        if ($this->moduleConfiguration->getFallbackGenerationMode($storeId) === Fallback::PREFIX) {
-            $prefix = $this->moduleConfiguration->getFallbackSessionIdPrefix($storeId);
-            if (!$prefix) {
-                $prefix = '9999';
-            }
-
-            return $prefix . random_int((int)1E5, (int)1E6);
-        }
-
-        return random_int((int)1E5, (int)1E9);
-    }
-
-    /**
-     * Try to get the Google Analytics User ID from the cookie
-     *
-     * @return string|null
-     */
-    protected function getUserIdFromCookie()
-    {
-        $gaCookie = explode('.', $this->cookieManager->getCookie('_ga') ?? '');
-
-        if (count($gaCookie) < 4) {
-            return null;
-        }
-
-        [
-            $gaCookieVersion,
-            $gaCookieDomainComponents,
-            $gaCookieUserId,
-            $gaCookieTimestamp
-        ] = $gaCookie;
-
-        if (!$gaCookieUserId || !$gaCookieTimestamp) {
-            return null;
-        }
-
-        if (
-            $gaCookieVersion != 'GA' . $this->gaclient->getVersion()
-        ) {
-            $this->gaclient->createLog(
-                'Google Analytics cookie version differs from Measurement Protocol API version; please upgrade.'
-            );
-            return null;
-        }
-
-        return implode('.', [$gaCookieUserId, $gaCookieTimestamp]);
-    }
-
-    protected function getSessionIdFromCookie(int|null|string $storeId = null)
-    {
-        $gaMeasurementId = $this->moduleConfiguration->getMeasurementId($storeId);
-        $gaMeasurementId = str_replace('G-', '', $gaMeasurementId);
-
-        $gaCookie = explode(
-            '.',
-            $this->cookieManager->getCookie('_ga_' . $gaMeasurementId) ?? ''
-        );
-
-        if (count($gaCookie) < 9) {
-            return null;
-        }
-
-        return $gaCookie[2];
     }
 }


### PR DESCRIPTION
This is somewhat of a large PR, luckily most of it has been moving functions around.

The aim of this PR is to support creating the GA analytics data when the order gets created.

**why?**
Because not every module actually creates a cart in a way that it triggers SaveGaUserDataToDb
For example: Channable


So we're better off attempting to create it if it doesn't exist during the order creation as well since that will always exist.
We might always miss the link to the user session, but at least we do have the purchase events.

Due to the separation of concerns with:
 - "getUserIdFromCookie"
 - "getGaUserId"
 - "generateFallbackUserId"

We should also never again run into PRs like https://github.com/elgentos/magento2-serversideanalytics/pull/55
since order of execution is clearly defined as:
`getUserIdFromCookie() ?? getGaUserId() ?? generateFallbackUserId()`

Thus the fallback generation will only run **once** per quote/order which has not been the case before, 
since `getUserIdFromCookie` also handled `generateFallbackUserId` turning execution order into:
`getUserIdFromCookie() ?? generateFallbackUserId() ?? getGaUserId()`
Making the database value essentially useless.