### PR TITLE
Correctly listen to PaymentMethod trigger

### DIFF
--- a/Config/ModuleConfiguration.php
+++ b/Config/ModuleConfiguration.php
@@ -132,7 +132,7 @@ class ModuleConfiguration extends AbstractConfigProvider
             return true;
         }
 
-        return true;
+        return false;
     }
 
     public function getTriggerMode(int|null|string $storeId = null): ?int


### PR DESCRIPTION
Previous configuration accidentally always returned true if trigger was set to payment method dependent