### PR TITLE
Fixed optional parameter order

### DIFF
--- a/Model/SalesOrder.php
+++ b/Model/SalesOrder.php
@@ -24,13 +24,13 @@ class SalesOrder extends AbstractModel
     public function __construct(
         Context $context,
         Registry $registry,
-        SalesOrderResource $resource = null,
-        AbstractDb $resourceCollection = null,
         protected readonly ModuleConfiguration $moduleConfiguration,
         protected readonly CollectionFactory $elgentosSalesOrderCollectionFactory,
         protected readonly SalesOrderRepository $elgentosSalesOrderRepository,
         protected readonly CookieManagerInterface $cookieManager,
         protected readonly GAClient $gaclient,
+        SalesOrderResource $resource = null,
+        AbstractDb $resourceCollection = null,
         array $data = []
     ) {
         parent::__construct($context, $registry, $resource, $resourceCollection, $data);


### PR DESCRIPTION
Before this change an error would occur **only** after having run setup:di:compile

When the following graphql mutation is run `mutation { createEmptyCart }` an error would be returned `Cannot instantiate abstract class Magento\Framework\Data\Collection\AbstractDb` 

This seems to be because Magento does not agree with the ordering of the arguments.